### PR TITLE
refactor: improve weather helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,9 @@ Check out the [screenshots/](./screenshots) folder for sample interactions with 
 
 There are tons of Weather APIs out there which are free to sign up and use, but for this PoC in particular I use the [OpenWeatherMap](https://openweathermap.org/) API. You can sign up on their site for free and get an API key which the bot can use to make requests to get the weather data.
 
-Once you have a working API key, replace the value for `openWeatherAPIKey` at the top of the [weather.ts](./bot/weather.ts#L4) file - also copied below.
-
-```
-const openWeatherAPIKey = "TODO-REPLACE-ME";
-```
+Once you have a working API key, store it in an environment variable named
+`OPENWEATHER_API_KEY`. The bot reads this value at runtime so secrets don't have
+to be committed to source control.
 
 ## Helpful Links
 

--- a/bot/teamsBot.ts
+++ b/bot/teamsBot.ts
@@ -149,12 +149,12 @@ export class TeamsBot extends TeamsActivityHandler {
 
   async renderCoords(
     forecastType: "hourly" | "daily",
-    lat: number = null,
-    lon: number = null,
-    cityName: string = null,
-    countryCode: string = null
+    lat: number | null = null,
+    lon: number | null = null,
+    cityName: string | null = null,
+    countryCode: string | null = null
   ) {
-    if (!lat || !lon) {
+    if (lat === null || lon === null) {
       console.log("Retrieving Longitude and Latitude Coordinates");
       const weatherResp = await getHourlyForecast(cityName, countryCode);
       lat = weatherResp.city.coord.lat;

--- a/bot/weather.ts
+++ b/bot/weather.ts
@@ -1,7 +1,10 @@
 import axios from "axios";
 export const tzlookup = require("tz-lookup");
 
-const openWeatherAPIKey = "TODO-REPLACE-ME";
+// Read the OpenWeatherMap API key from environment variables so credentials
+// aren't hardcoded in source control. Fall back to a placeholder to help
+// developers notice when the key hasn't been configured yet.
+const openWeatherAPIKey = process.env.OPENWEATHER_API_KEY || "TODO-REPLACE-ME";
 
 export async function getHourlyForecast(
   cityName: string,
@@ -21,7 +24,7 @@ export async function getAllInOneForecast(
   lat: number,
   lon: number,
   units: "standard" | "metric" | "imperial" = "imperial",
-  exclude: Array<String> = ["minutely"]
+  exclude: string[] = ["minutely"]
 ): Promise<any> {
   const excludeVal = exclude.join(",").toLowerCase();
 
@@ -34,10 +37,10 @@ export async function getAllInOneForecast(
 
 export function weatherIconUrl(iconCode: string): string {
   /** Ref: https://openweathermap.org/weather-conditions */
-  return `http://openweathermap.org/img/wn/${iconCode}@2x.png`;
+  return `https://openweathermap.org/img/wn/${iconCode}@2x.png`;
 }
 
-export function getCardinalDirection(angle) {
+export function getCardinalDirection(angle: number): string {
   const directions = [
     "↑ N",
     "↗ NE",
@@ -52,8 +55,9 @@ export function getCardinalDirection(angle) {
 }
 
 export function toFahrenheit(kelvin: number): number {
-  // Convert a value in Kelvin to a value in Fahrenheit.
-  return 1.8 * (kelvin - 273) + 32;
+  // Convert a value in Kelvin to a value in Fahrenheit using the precise
+  // zero offset of 273.15.
+  return 1.8 * (kelvin - 273.15) + 32;
 }
 
 async function main() {


### PR DESCRIPTION
## Summary
- avoid hard-coding OpenWeather API key and pull from environment
- fix coordinate handling in `renderCoords` when latitude or longitude is zero
- use HTTPS for weather icons and correct Kelvin to Fahrenheit conversion

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af1e3a6180832d84b6ac26ba52f36d