### PR TITLE
feat: allow metric and imperial weather units

### DIFF
--- a/bot/adaptiveCards/weather-forecast-daily.json
+++ b/bot/adaptiveCards/weather-forecast-daily.json
@@ -2,7 +2,7 @@
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
   "type": "AdaptiveCard",
   "version": "1.5",
-  "speak": "<s>Weather forecast for ${formatEpoch(data[0].sunrise_ts, 'dddd')} is high of ${formatNumber(data[0].app_max_temp / 5 * 9 + 32, 0)} and low of ${formatNumber(data[0].app_min_temp / 5 * 9 + 32, 0)} degrees with a ${formatNumber(data[0].precip * 100, 0)}% chance of rain</s><s>Winds will be ${formatNumber(data[0].wind_gust_spd, 0)} mph from the ${data[0].wind_cdir}</s>",
+  "speak": "<s>Weather forecast for ${formatEpoch(data[0].sunrise_ts, 'dddd')} is high of ${formatNumber(data[0].app_max_temp, 0)}°${tempUnit} and low of ${formatNumber(data[0].app_min_temp, 0)}°${tempUnit} degrees with a ${formatNumber(data[0].precip * 100, 0)}% chance of rain</s><s>Winds will be ${formatNumber(data[0].wind_gust_spd, 0)} ${windSpeedUnit} from the ${data[0].wind_cdir}</s>",
   "backgroundImage": {
     "url": "https://messagecardplayground.azurewebsites.net/assets/Mostly%20Cloudy-Background.jpg"
   },
@@ -40,7 +40,7 @@
             },
             {
               "type": "TextBlock",
-              "text": "${formatNumber(daily[0].temp.min, 0)} / ${formatNumber(daily[0].temp.max, 0)}",
+              "text": "${formatNumber(daily[0].temp.min, 0)}°${tempUnit} / ${formatNumber(daily[0].temp.max, 0)}°${tempUnit}",
               "size": "Medium",
               "spacing": "None",
               "wrap": true
@@ -53,7 +53,7 @@
             },
             {
               "type": "TextBlock",
-              "text": "Winds ${daily[0].wind_speed} mph ${daily[0].wind_cdir}",
+              "text": "Winds ${daily[0].wind_speed} ${windSpeedUnit} ${daily[0].wind_cdir}",
               "spacing": "None",
               "wrap": true
             }
@@ -86,11 +86,11 @@
               "facts": [
                 {
                   "title": "High",
-                  "value": "${formatNumber(temp.max, 0)}"
+                  "value": "${formatNumber(temp.max, 0)}°${tempUnit}"
                 },
                 {
                   "title": "Low",
-                  "value": "${formatNumber(temp.min, 0)}"
+                  "value": "${formatNumber(temp.min, 0)}°${tempUnit}"
                 },
                 {
                   "title": "Note",
@@ -132,11 +132,11 @@
               "facts": [
                 {
                   "title": "High",
-                  "value": "${formatNumber(temp.max, 0)}"
+                  "value": "${formatNumber(temp.max, 0)}°${tempUnit}"
                 },
                 {
                   "title": "Low",
-                  "value": "${formatNumber(temp.min, 0)}"
+                  "value": "${formatNumber(temp.min, 0)}°${tempUnit}"
                 },
                 {
                   "title": "Note",

--- a/bot/adaptiveCards/weather-forecast-today.json
+++ b/bot/adaptiveCards/weather-forecast-today.json
@@ -2,7 +2,7 @@
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
   "type": "AdaptiveCard",
   "version": "1.5",
-  "speak": "<s>Weather forecast for ${formatEpoch(data[0].sunrise_ts, 'dddd')} is high of ${formatNumber(data[0].app_max_temp / 5 * 9 + 32, 0)} and low of ${formatNumber(data[0].app_min_temp / 5 * 9 + 32, 0)} degrees with a ${formatNumber(data[0].precip * 100, 0)}% chance of rain</s><s>Winds will be ${formatNumber(data[0].wind_gust_spd, 0)} mph from the ${data[0].wind_cdir}</s>",
+  "speak": "<s>Weather forecast for ${formatEpoch(data[0].sunrise_ts, 'dddd')} is high of ${formatNumber(data[0].app_max_temp, 0)}°${tempUnit} and low of ${formatNumber(data[0].app_min_temp, 0)}°${tempUnit} degrees with a ${formatNumber(data[0].precip * 100, 0)}% chance of rain</s><s>Winds will be ${formatNumber(data[0].wind_gust_spd, 0)} ${windSpeedUnit} from the ${data[0].wind_cdir}</s>",
   "backgroundImage": {
     "url": "https://messagecardplayground.azurewebsites.net/assets/Mostly%20Cloudy-Background.jpg"
   },
@@ -41,7 +41,7 @@
             },
             {
               "type": "TextBlock",
-              "text": "${formatNumber(hourly[0].feels_like, 0)} / ${formatNumber(hourly[0].temp, 0)}",
+              "text": "${formatNumber(hourly[0].feels_like, 0)}°${tempUnit} / ${formatNumber(hourly[0].temp, 0)}°${tempUnit}",
               "size": "Medium",
               "spacing": "None",
               "wrap": true
@@ -54,7 +54,7 @@
             },
             {
               "type": "TextBlock",
-              "text": "Winds ${hourly[0].wind_speed} mph ${hourly[0].wind_cdir}",
+              "text": "Winds ${hourly[0].wind_speed} ${windSpeedUnit} ${hourly[0].wind_cdir}",
               "spacing": "None",
               "wrap": true
             }
@@ -87,11 +87,11 @@
               "facts": [
                 {
                   "title": "Temp",
-                  "value": "${formatNumber(temp, 0)}"
+                  "value": "${formatNumber(temp, 0)}°${tempUnit}"
                 },
                 {
                   "title": "Feels Like",
-                  "value": "${formatNumber(feels_like, 0)}"
+                  "value": "${formatNumber(feels_like, 0)}°${tempUnit}"
                 }
               ]
             }
@@ -129,11 +129,11 @@
               "facts": [
                 {
                   "title": "Temp",
-                  "value": "${formatNumber(temp, 0)}"
+                  "value": "${formatNumber(temp, 0)}°${tempUnit}"
                 },
                 {
                   "title": "Feels Like",
-                  "value": "${formatNumber(feels_like, 0)}"
+                  "value": "${formatNumber(feels_like, 0)}°${tempUnit}"
                 }
               ]
             }
@@ -171,11 +171,11 @@
               "facts": [
                 {
                   "title": "Temp",
-                  "value": "${formatNumber(temp, 0)}"
+                  "value": "${formatNumber(temp, 0)}°${tempUnit}"
                 },
                 {
                   "title": "Feels Like",
-                  "value": "${formatNumber(feels_like, 0)}"
+                  "value": "${formatNumber(feels_like, 0)}°${tempUnit}"
                 }
               ]
             }

--- a/bot/adaptiveCards/weather-input.json
+++ b/bot/adaptiveCards/weather-input.json
@@ -14,6 +14,23 @@
       "text": "Enter a preset city name, or manually enter a city / country.",
       "wrap": true,
       "spacing": "Medium"
+    },
+    {
+      "type": "Input.ChoiceSet",
+      "label": "Units",
+      "id": "units",
+      "value": "imperial",
+      "style": "compact",
+      "choices": [
+        {
+          "title": "Fahrenheit (°F)",
+          "value": "imperial"
+        },
+        {
+          "title": "Celsius (°C)",
+          "value": "metric"
+        }
+      ]
     }
   ],
   "actions": [

--- a/bot/teamsBot.ts
+++ b/bot/teamsBot.ts
@@ -152,11 +152,12 @@ export class TeamsBot extends TeamsActivityHandler {
     lat: number | null = null,
     lon: number | null = null,
     cityName: string | null = null,
-    countryCode: string | null = null
+    countryCode: string | null = null,
+    units: "standard" | "metric" | "imperial" = "imperial"
   ) {
     if (lat === null || lon === null) {
       console.log("Retrieving Longitude and Latitude Coordinates");
-      const weatherResp = await getHourlyForecast(cityName, countryCode);
+      const weatherResp = await getHourlyForecast(cityName, countryCode, units);
       lat = weatherResp.city.coord.lat;
       lon = weatherResp.city.coord.lon;
 
@@ -165,9 +166,11 @@ export class TeamsBot extends TeamsActivityHandler {
 
     console.log("Retrieving All-In-One Forecast");
 
-    const res = await getAllInOneForecast(lat, lon);
+    const res = await getAllInOneForecast(lat, lon, units);
 
     res.loc = cityName;
+    const tempUnit = units === "metric" ? "C" : "F";
+    const windSpeedUnit = units === "metric" ? "m/s" : "mph";
 
     console.log("Result:", JSON.stringify(res));
 
@@ -191,6 +194,8 @@ export class TeamsBot extends TeamsActivityHandler {
     return this.renderAdaptiveCard(card, {
       ...res,
       data: data,
+      tempUnit,
+      windSpeedUnit,
     });
   }
 
@@ -214,11 +219,14 @@ export class TeamsBot extends TeamsActivityHandler {
         break;
       }
       case "dailyForecastForReston": {
+        const { units } = invokeValue.action.data as Dictionary<string>;
         const card = await this.renderCoords(
           "daily",
           38.9687,
           -77.3411,
-          "Reston, VA"
+          "Reston, VA",
+          undefined,
+          units as "standard" | "metric" | "imperial"
         );
 
         await context.updateActivity({
@@ -230,11 +238,14 @@ export class TeamsBot extends TeamsActivityHandler {
       }
 
       case "todayForecastForReston": {
+        const { units } = invokeValue.action.data as Dictionary<string>;
         const card = await this.renderCoords(
           "hourly",
           38.9687,
           -77.3411,
-          "Reston, VA"
+          "Reston, VA",
+          undefined,
+          units as "standard" | "metric" | "imperial"
         );
 
         await context.updateActivity({
@@ -245,11 +256,14 @@ export class TeamsBot extends TeamsActivityHandler {
         break;
       }
       case "todayForecastForSacramento": {
+        const { units } = invokeValue.action.data as Dictionary<string>;
         const card = await this.renderCoords(
           "hourly",
           38.4666,
           -121.3177,
-          "Sacramento, CA"
+          "Sacramento, CA",
+          undefined,
+          units as "standard" | "metric" | "imperial"
         );
 
         await context.updateActivity({
@@ -260,11 +274,14 @@ export class TeamsBot extends TeamsActivityHandler {
         break;
       }
       case "dailyForecastForSacramento": {
+        const { units } = invokeValue.action.data as Dictionary<string>;
         const card = await this.renderCoords(
           "daily",
           38.4666,
           -121.3177,
-          "Sacramento, CA"
+          "Sacramento, CA",
+          undefined,
+          units as "standard" | "metric" | "imperial"
         );
 
         await context.updateActivity({
@@ -275,13 +292,14 @@ export class TeamsBot extends TeamsActivityHandler {
         break;
       }
       case "todayForecastWithCity": {
-        const { city, country } = invokeValue.action.data as Dictionary<string>;
+        const { city, country, units } = invokeValue.action.data as Dictionary<string>;
         const card = await this.renderCoords(
           "hourly",
           null,
           null,
           city,
-          country
+          country,
+          units as "standard" | "metric" | "imperial"
         );
 
         await context.updateActivity({
@@ -293,13 +311,14 @@ export class TeamsBot extends TeamsActivityHandler {
         break;
       }
       case "dailyForecastWithCity": {
-        const { city, country } = invokeValue.action.data as Dictionary<string>;
+        const { city, country, units } = invokeValue.action.data as Dictionary<string>;
         const card = await this.renderCoords(
           "daily",
           null,
           null,
           city,
-          country
+          country,
+          units as "standard" | "metric" | "imperial"
         );
 
         await context.updateActivity({


### PR DESCRIPTION
## Summary
- let users choose Fahrenheit or Celsius in the weather input card
- thread unit selection through forecast rendering
- show temperature and wind speed using chosen units

## Testing
- `npm --prefix bot run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b0caaf9658832dbe18269aa954213b